### PR TITLE
replace location with azureRegion

### DIFF
--- a/base-azure-network/main.tf
+++ b/base-azure-network/main.tf
@@ -9,14 +9,14 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "rg" {
   name     = "${var.projectPrefix}-f5-xc"
-  location = var.location
+  location = var.azureRegion
 }
 
 
 resource "azurerm_network_security_group" "f5-xc-nsg" {
   name                = "f5_xc_nsg"
   resource_group_name = azurerm_resource_group.rg.name
-  location            = var.location
+  location            = var.azureRegion
 }
 
 
@@ -96,7 +96,7 @@ resource "azurerm_network_security_rule" "allow_dns2" {
 
 resource "azurerm_virtual_network" "f5-xc-hub" {
   name                = "f5_xc_hub_vnet"
-  location            = var.location
+  location            = var.azureRegion
   address_space       = [var.servicesVnetAddressSpace]
   resource_group_name = azurerm_resource_group.rg.name
 }
@@ -125,7 +125,7 @@ resource "azurerm_subnet" "workload" {
 
 resource "azurerm_route_table" "workload" {
   name                = "workload_rt"
-  location            = var.location
+  location            = var.azureRegion
   resource_group_name = azurerm_resource_group.rg.name
 }
 

--- a/base-azure-network/peer.tf
+++ b/base-azure-network/peer.tf
@@ -3,7 +3,7 @@
 resource "azurerm_network_security_group" "f5-xc-peer-nsg" {
   name                = "f5_xc_peer_nsg"
   resource_group_name = azurerm_resource_group.rg.name
-  location            = var.location
+  location            = var.azureRegion
 }
 
 
@@ -39,7 +39,7 @@ resource "azurerm_network_security_rule" "f5-xc-peer-nsg-rule2" {
 
 resource "azurerm_virtual_network" "f5-xc-peer" {
   name                = "f5_xc_spoke_vnet"
-  location            = var.location
+  location            = var.azureRegion
   address_space       = [var.spokeVnetAddressSpace]
   resource_group_name = azurerm_resource_group.rg.name
 }
@@ -68,7 +68,7 @@ resource "azurerm_subnet" "workload-peer" {
 
 resource "azurerm_route_table" "workload-peer" {
   name                = "workload-peer_rt"
-  location            = var.location
+  location            = var.azureRegion
   resource_group_name = azurerm_resource_group.rg.name
 }
 

--- a/base-azure-network/variables.tf
+++ b/base-azure-network/variables.tf
@@ -18,11 +18,6 @@ variable "resourceGroup" {
   default     = "f5demo_rg"
 }
 
-variable "location" {
-  description = "The location/region where the virtual networks are created. Changing this forces a new resource to be created."
-  default     = "eastus"
-}
-
 variable "trusted_ip" {
   description = "IP address of trusted source for mgmt/testing"
   default     = "192.0.2.10/32"


### PR DESCRIPTION
base-azure-network used location variable and ignored azureRegion defined in the toplevel terragrunt.hcl. This merge request replaces var.location with var.azureRegion and removes the now unused location variable.