### PR TITLE
adding mock_outputs

### DIFF
--- a/azure-apps/terragrunt.hcl
+++ b/azure-apps/terragrunt.hcl
@@ -17,6 +17,9 @@ dependencies {
 
 dependency "workloads" {
   config_path = "../azure-workload"
+  mock_outputs = {
+    workload_private_ip = "1.1.1.1"
+  }
 }
 
 inputs = {

--- a/azure-apps2/terragrunt.hcl
+++ b/azure-apps2/terragrunt.hcl
@@ -8,6 +8,9 @@ dependencies {
 
 dependency "workloads" {
   config_path = "../azure-workload2"
+  mock_outputs = {
+    workload_private_ip = ""
+  }
 }
 
 inputs = {

--- a/azure-site/terragrunt.hcl
+++ b/azure-site/terragrunt.hcl
@@ -8,6 +8,10 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-azure-network"
+  mock_outputs = {
+    resourceGroup = "foo"
+    hubVnetName = ""
+  }
 }
 
 inputs = {

--- a/azure-site2/terragrunt.hcl
+++ b/azure-site2/terragrunt.hcl
@@ -8,6 +8,10 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-azure-network2"
+  mock_outputs = {
+    resourceGroup = "foo"
+    hubVnetName = ""
+  }
 }
 
 inputs = {

--- a/azure-workload/terragrunt.hcl
+++ b/azure-workload/terragrunt.hcl
@@ -18,6 +18,11 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-azure-network"
+  mock_outputs = {
+    resourceGroup = "foo"
+    hubVnetName = ""
+    workloadSubnet = ""
+  }
 }
 
 inputs = {

--- a/azure-workload2/terragrunt.hcl
+++ b/azure-workload2/terragrunt.hcl
@@ -18,6 +18,11 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-azure-network2"
+  mock_outputs = {
+    resourceGroup = "foo"
+    hubVnetName = ""
+    workloadSubnet = ""
+  }
 }
 
 inputs = {

--- a/base-aws-network/terragrunt.hcl
+++ b/base-aws-network/terragrunt.hcl
@@ -2,6 +2,6 @@ include "root" {
   path = find_in_parent_folders()
 }
 
-dependencies {
-  paths = []
-}
+#dependencies {
+#  paths = []
+#}

--- a/base-aws-network2/terragrunt.hcl
+++ b/base-aws-network2/terragrunt.hcl
@@ -2,6 +2,6 @@ include "root" {
   path = find_in_parent_folders()
 }
 
-dependencies {
-  paths = []
-}
+#dependencies {
+#  paths = []
+#}

--- a/tgw-apps-1-to-2/terragrunt.hcl
+++ b/tgw-apps-1-to-2/terragrunt.hcl
@@ -9,10 +9,17 @@ dependencies {
 
 dependency "workloads" {
   config_path = "../tgw-workload"
+  mock_outputs = {
+    workload_ip = ""
+    workload_ip2 = ""
+  }
 }
 
 dependency "workloads2" {
   config_path = "../tgw-workload2"
+  mock_outputs = {
+    workload_ip = ""
+  }
 }
 
 inputs = {

--- a/tgw-apps/terragrunt.hcl
+++ b/tgw-apps/terragrunt.hcl
@@ -10,6 +10,10 @@ dependencies {
 
 dependency "workloads" {
   config_path = "../tgw-workload"
+  mock_outputs = {
+    workload_ip = ""
+    workload_ip2 = ""
+  }
 }
 
 inputs = {

--- a/tgw-route53-1-to-2/terragrunt.hcl
+++ b/tgw-route53-1-to-2/terragrunt.hcl
@@ -9,36 +9,80 @@ dependencies {
 
 dependency "workloads" {
   config_path = "../tgw-workload"
+  mock_outputs = {
+  }
 }
 
 dependency "workloads2" {
   config_path = "../tgw-workload2"
+  mock_outputs = {
+  }
 }
 
 dependency "infrastructure" {
   config_path = "../base-aws-network"
+  mock_outputs = {
+    "externalSubnets" = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    vpcId = ""
+  }
 }
 
 dependency "infrastructure2" {
   config_path = "../base-aws-network2"
+  mock_outputs = {
+    "externalSubnets" = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      }
+    }
+    vpcId = ""
+    securityGroup = ""
+  }
 }
 
 dependency "tgw1route53" {
   config_path = "../tgw-site-ext-lb"
+  mock_outputs = {
+    route54zoneid = "foo"
+    nlbdnsname = ""
+  }
 }
 
 dependency "site" {
   config_path = "../tgw-site"
+  mock_outputs = {
+    public_ips = ["1.1.1.1","1.1.1.1","1.1.1.1"]
+    private_ips = ["1.1.1.1","1.1.1.1","1.1.1.1"]
+  }
 }
 dependency "site2" {
   config_path = "../tgw-site2"
+  mock_outputs = {
+    public_ips = ["1.1.1.1","1.1.1.1","1.1.1.1"]
+    private_ips = ["1.1.1.1","1.1.1.1","1.1.1.1"]
+  }
 }
 
 dependency "site3" {
   config_path = "../azure-site"
+  mock_outputs = {
+    public_ips = ["1.1.1.1","1.1.1.1","1.1.1.1"]
+    private_ips = ["1.1.1.1","1.1.1.1","1.1.1.1"]
+  }
 }
 dependency "site4" {
   config_path = "../azure-site2"
+  mock_outputs = {
+    public_ips = ["1.1.1.1","1.1.1.1","1.1.1.1"]
+    private_ips = ["1.1.1.1","1.1.1.1","1.1.1.1"]
+  }
 }
 
 

--- a/tgw-site-ext-lb/terragrunt.hcl
+++ b/tgw-site-ext-lb/terragrunt.hcl
@@ -8,6 +8,44 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-aws-network"
+  mock_outputs = {
+    awsAz1 = ""
+    awsAz2 = ""
+    awsAz3 = ""
+    externalSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      }
+    }
+    internalSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    workloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spokeExternalSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spokeWorkloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    securityGroup = ""
+    vpcId = "foo"
+    spokeVpcId = ""
+    spoke2VpcId = ""
+    spokeSecurityGroup = ""
+  }
 }
 
 inputs = {

--- a/tgw-site/terragrunt.hcl
+++ b/tgw-site/terragrunt.hcl
@@ -8,6 +8,71 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-aws-network"
+  mock_outputs = {
+    awsAz1 = ""
+    awsAz2 = ""
+    awsAz3 = ""
+    externalSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    internalSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    workloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    spokeExternalSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    spokeWorkloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    securityGroup = ""
+    vpcId = ""
+    spokeVpcId = ""
+    spoke2VpcId = ""
+    spokeSecurityGroup = ""
+  }
 }
 
 inputs = {

--- a/tgw-site2/terragrunt.hcl
+++ b/tgw-site2/terragrunt.hcl
@@ -8,6 +8,70 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-aws-network2"
+  mock_outputs = {
+    awsAz1 = ""
+    awsAz2 = ""
+    awsAz3 = ""
+    securityGroup = ""
+    externalSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    internalSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    workloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    spokeExternalSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    spokeWorkloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      },
+      "az2" = {
+        "id" = "2"
+      },
+      "az3" = {
+        "id" = "3"
+      }
+    }
+    vpcId = ""
+    spokeVpcId = ""
+    spokeSecurityGroup = ""
+  }
 }
 
 inputs = {

--- a/tgw-vpc-peer-1-2/terragrunt.hcl
+++ b/tgw-vpc-peer-1-2/terragrunt.hcl
@@ -8,9 +8,56 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-aws-network"
+  mock_outputs = {
+    awsAz1 = ""
+    awsAz2 = ""
+    awsAz3 = ""
+    "externalSubnets" = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    internalSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    workloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spokeExternalSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spokeExternalSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spokeWorkloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    securityGroup = ""
+    vpcId = ""
+    spokeVpcId = ""
+    spoke2VpcId = ""
+    serviceCidrBlock = "0.0.0.0/0"
+    serviceExternalRouteTable = ""
+    spokeSecurityGroup = ""
+  }
 }
 dependency "infrastructure2" {
   config_path = "../base-aws-network2"
+  mock_outputs = {
+    vpcId = ""
+    serviceExternalRouteTable = ""
+    serviceCidrBlock = "0.0.0.0/0"
+  }
 }
 inputs = {
     awsAz1               = dependency.infrastructure.outputs.awsAz1

--- a/tgw-workload/terragrunt.hcl
+++ b/tgw-workload/terragrunt.hcl
@@ -18,6 +18,38 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-aws-network"
+  mock_outputs = {
+    spokeExternalSubnets= {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spokeWorkloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spokeSecurityGroup = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spoke2ExternalSubnets= {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spoke2WorkloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spoke2SecurityGroup = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+  }
 }
 
 inputs = {

--- a/tgw-workload2/terragrunt.hcl
+++ b/tgw-workload2/terragrunt.hcl
@@ -18,6 +18,23 @@ dependencies {
 
 dependency "infrastructure" {
   config_path = "../base-aws-network2"
+  mock_outputs = {
+    spokeExternalSubnets= {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spokeWorkloadSubnets = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+    spokeSecurityGroup = {
+      "az1" = {
+        "id" = "1"
+      }
+    }
+  }
 }
 
 inputs = {


### PR DESCRIPTION
Add mock_outputs to allow `terragrunt run-all destroy` to succeed in all cases (e.g. in case of deployment failures). 

Haven't run a full deploy/destroy to validate. Will remove [wip] once done, but wanted to share this to avoid potential duplication efforts.