### PR TITLE
fixing lifecycle ignore changes label

### DIFF
--- a/azure-site2/azure-site.tf
+++ b/azure-site2/azure-site.tf
@@ -220,6 +220,10 @@ resource "volterra_azure_vnet_site" "azure-site" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [labels]
+  }
+
 }
 
 resource "volterra_cloud_site_labels" "labels" {


### PR DESCRIPTION
azure-site2 missed parts of the lifecycle_change fix for labels.